### PR TITLE
feat: add full-screen custom note editor

### DIFF
--- a/client/src/components/CustomNoteEditor.tsx
+++ b/client/src/components/CustomNoteEditor.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { DotPhraseTextarea } from '@/components/DotPhraseTextarea';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { ChevronLeft, Edit3 } from 'lucide-react';
+
+interface CustomNoteEditorProps {
+  note: string;
+  onChange: (value: string) => void;
+  onBack: () => void;
+}
+
+export function CustomNoteEditor({ note, onChange, onBack }: CustomNoteEditorProps) {
+  const { language } = useLanguage();
+  return (
+    <div className="flex flex-col h-full w-full">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Edit3 className="w-6 h-6 text-orange-600" />
+          <h2 className="text-xl font-semibold text-gray-900">
+            {language === 'fr' ? 'Note Personnalisée' : 'Custom Note'}
+          </h2>
+        </div>
+        <Button
+          onClick={onBack}
+          variant="outline"
+          size="sm"
+          className="flex items-center gap-1"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          {language === 'fr' ? 'Retour' : 'Back to Note Types'}
+        </Button>
+      </div>
+      <div className="flex-1">
+        <DotPhraseTextarea
+          value={note}
+          onChange={onChange}
+          placeholder={language === 'fr' ? 'Commencez votre note...' : 'Start your note...'}
+          className="w-full h-full min-h-[80vh] font-mono text-base resize-none border border-gray-200 rounded-lg p-4"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default CustomNoteEditor;

--- a/client/src/pages/review-of-systems.tsx
+++ b/client/src/pages/review-of-systems.tsx
@@ -27,7 +27,6 @@ import {
   Bone,
   Shield,
   Activity,
-  ChevronLeft,
   ChevronRight,
   ClipboardList,
   Search,
@@ -96,6 +95,7 @@ import HpiSection from '@/components/HpiSection';
 import { TemplateAwareLivePreview } from '@/components/TemplateAwareLivePreview';
 import { usePersistedState } from '@/hooks/usePersistedState';
 import { useDebounceCallback } from '@/hooks/useDebounce';
+import { CustomNoteEditor } from '@/components/CustomNoteEditor';
 
 import { type TemplateContent, getSectionById } from '@/lib/sectionLibrary';
 
@@ -1947,35 +1947,11 @@ function ReviewOfSystems({ selectedMenu, setSelectedMenu, selectedSubOption, set
       case "note-type":
   if ((noteType as string) === "custom") {
     return (
-      <div className="flex flex-col h-full">
-        {/* Header with back button */}
-        <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Edit3 className="w-6 h-6 text-orange-600" />
-            <h2 className="text-xl font-semibold text-gray-900">
-              {language === 'fr' ? 'Note Personnalisée' : 'Custom Note'}
-            </h2>
-          </div>
-          <Button
-            onClick={() => setNoteTypeState('')}
-            variant="outline"
-            size="sm"
-            className="flex items-center gap-1"
-          >
-            <ChevronLeft className="w-4 h-4" />
-            {language === 'fr' ? 'Retour' : 'Back to Note Types'}
-          </Button>
-        </div>
-        
-        {/* Expanded Live Preview - optimized for custom note editing */}
-        <div className="flex-1 flex">
-          <div className="w-full max-w-none px-0">
-            <div className="h-full">
-              {renderLivePreview()}
-            </div>
-          </div>
-        </div>
-      </div>
+      <CustomNoteEditor
+        note={note || ''}
+        onChange={handleNoteChange}
+        onBack={() => setNoteTypeState('')}
+      />
     );
   }
         return (


### PR DESCRIPTION
## Summary
- add dedicated CustomNoteEditor component with dot-phrase enabled full-screen textarea
- use CustomNoteEditor when selecting the custom note type to remove container constraints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6896b74ff91483239a846e5614f433cb